### PR TITLE
Ensure beta button uses bold white text

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -763,6 +763,12 @@ p {
   width: 100%;
 }
 
+/* Ensure the beta access button text is always white and bold */
+.navbar-nav .nav-item .main-btn {
+  color: #fff;
+  font-weight: 700;
+}
+
 /* ====== hero-area ===== */
 .hero-section {
   position: relative;


### PR DESCRIPTION
## Summary
- keep Acessar Beta navigation button text white and bold

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a88d94ecb48324bbe7fdc00ea308e5