### PR TITLE
Ensure beta button text is always white and bold

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -764,7 +764,11 @@ p {
 }
 
 /* Ensure the beta access button text is always white and bold */
-.navbar-nav .nav-item .main-btn {
+.navbar-nav .nav-item .main-btn,
+.navbar-nav .nav-item .main-btn:visited,
+.navbar-nav .nav-item .main-btn:hover,
+.navbar-nav .nav-item .main-btn:focus,
+.navbar-nav .nav-item .main-btn:active {
   color: #fff;
   font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- guarantee the beta navigation button text remains bold and white across all link states

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aef29ad8148324b71c88615ded01ac