### PR TITLE
fix: keep beta button text white on scroll

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -617,11 +617,11 @@ p {
   }
 }
 
-.sticky .navbar .navbar-nav .nav-item a {
+.sticky .navbar .navbar-nav .nav-item a:not(.main-btn) {
   color: #162447;
 }
 
-.sticky .navbar .navbar-nav .nav-item a::before {
+.sticky .navbar .navbar-nav .nav-item a:not(.main-btn)::before {
   color: #162447;
 }
 


### PR DESCRIPTION
## Summary
- avoid sticky navbar color override on beta access button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aef5876e10832492e430bf5cb50a1f